### PR TITLE
General bug fixes and improvements.

### DIFF
--- a/autoload/emoji_complete.vim
+++ b/autoload/emoji_complete.vim
@@ -14,15 +14,17 @@ func! s:init_emojis_once()
     if !has_key( emoji, 'emoji' )
       continue
     endif
-    call add( s:emojis, s:emoji_to_candidate( emoji ) )
+    for alias in emoji['aliases']
+      call add( s:emojis, s:emoji_to_candidate( emoji, alias ) )
+    endfor
   endfor
   let s:emoji_inited = 1
 endfunc
 
-func! s:emoji_to_candidate( emoji )
+func! s:emoji_to_candidate( emoji, alias )
   return {
   \ 'emoji' : a:emoji['emoji'],
-  \ 'word' : a:emoji['aliases'][0],
+  \ 'word' : a:alias,
   \ 'kind' : a:emoji['emoji'] . ' ',
   \ 'menu' : a:emoji['description'],
   \ 'icase' : 1,
@@ -50,7 +52,7 @@ func! emoji_complete#complete()
 endfunc
 
 func! s:emoji_expand()
-  augroup emoji_complete_done 
+  augroup emoji_complete_done
     au!
   augroup end
   let line = getline('.')

--- a/autoload/emoji_complete.vim
+++ b/autoload/emoji_complete.vim
@@ -38,15 +38,23 @@ func! emoji_complete#complete()
     return ""
   endif
   call s:init_emojis_once()
-  let line = getline('.')[ : col('.')-1]
-  let s:complete_start = match(line, '\w*$')
+  " The text from the beginning of the line up until before the cursor.
+  let line = getline('.')[ : col('.')-2]
+  let s:complete_start = match(line, '\(-1\|+1\|[-a-zA-Z0-9_]*\)$')
   if s:complete_start >= 0
     augroup emoji_complete_done
       au!
       au CompleteDone <buffer> call s:emoji_expand()
     augroup end
-    call complete( s:complete_start+1, s:emojis )
-    return "\<c-p>"
+    let prefix = line[s:complete_start : ]
+    let matches = []
+    for emoji in s:emojis
+      if emoji['word'] =~? '^' . prefix
+        call add( matches, emoji )
+      endif
+    endfor
+    call complete( s:complete_start+1, matches )
+    return ""
   endif
   return ""
 endfunc


### PR DESCRIPTION
This pull request tries to make the plugin behave more like any other built-in completion. It fixes some bugs and slightly changes some behaviors.
- (Already included in #1) Supports multiple aliases for the same emoji. Test it by autocompleting `thumbsup`.
- Correctly gets the preceding text by using `col('.')-2` instead of `col('.')-1`. This was written correctly in `s:emoji_expand()`, but was incorrect/buggy in `emoji_complete#complete()`.
- Improves the regular expression to match any possible alias, including `-1`, `+1`, `e-mail`, `non-potable_water`.
- Filters the auto-complete list upon first execution. This is the expected behavior, because that's how the other completions also work.
- Avoids executing `<C-P>` after first execution. This also mimics the behavior of other completions. This is specially important after filtering the list, because a list with a single item will behave correctly.
